### PR TITLE
Upgrade eudi-rqes-jvm to 0.7.0-SNAPSHOT and update other dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
 androidx-test = "1.7.0"
 bouncy-castle = "1.83"
-dependency-license-report = "3.0.1"
+dependency-license-report = "3.1.1"
 dependencycheck = "12.2.0"
-dokka = "2.1.0"
+dokka = "2.2.0"
 espresso-contrib = "3.7.0"
 espresso-core = "3.7.0"
-eudi-rqes-jvm = "0.6.2"
+eudi-rqes-jvm = "0.7.0-SNAPSHOT"
 gradle-plugin = "8.13.2"
 jacoco = "0.8.12"
 java = "17"
 junit-android = "1.3.0"
 kotlin = "2.2.21"
-kotlinx-io = "0.8.2"
+kotlinx-io = "0.9.0"
 kotlin-coroutines-test = "1.10.2"
 ktor = "3.2.3"
 mavenPublish = "0.36.0"
 mockk = "1.14.9"
-sonarqube = "7.2.2.6593"
+sonarqube = "7.2.3.7755"
 
 [libraries]
 android-junit = { module = "androidx.test.ext:junit", version.ref = "junit-android" }

--- a/licenses.md
+++ b/licenses.md
@@ -1,18 +1,18 @@
 
 # EUDI RQES Core library for Android
 ## Dependency License Report
-_2026-02-10 16:24:23 EET_
+_2026-03-31 11:45:16 EEST_
 ## Apache License, Version 2.0
 
 **1** **Group:** `io.ktor` **Name:** `ktor-client-android` **Version:** `3.2.3` 
 > - **POM Project URL**: [https://github.com/ktorio/ktor](https://github.com/ktorio/ktor)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**2** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `2.2.21` 
+**2** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `2.3.0` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**3** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-io-core` **Version:** `0.8.2` 
+**3** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-io-core` **Version:** `0.9.0` 
 > - **POM Project URL**: [https://github.com/Kotlin/kotlinx-io](https://github.com/Kotlin/kotlinx-io)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
+++ b/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
@@ -311,6 +311,7 @@ class RQESServiceImpl(
                         credentialAuthorizationSubject = CredentialAuthorizationSubject(
                             credentialRef = CredentialRef.ByCredentialID(credential.credentialID),
                             documentDigestList = documentDigestList,
+                            numSignatures = documentsToSign.size
                         ),
                         walletState = serverState
                     )

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
@@ -141,6 +141,7 @@ class AuthorizedImplTest {
             val credentialAuthorizationSubject = CredentialAuthorizationSubject(
                 credentialRef = CredentialRef.ByCredentialID(credentialInfo.credentialID),
                 documentDigestList = documentDigestList,
+                numSignatures = documents.size,
             )
             coEvery {
                 with(mockClient) {
@@ -268,6 +269,7 @@ class AuthorizedImplTest {
             val credentialAuthorizationSubject = CredentialAuthorizationSubject(
                 credentialRef = CredentialRef.ByCredentialID(credentialInfo.credentialID),
                 documentDigestList = documentDigestList,
+                numSignatures = documents.size,
             )
             coEvery {
                 with(mockClient) {
@@ -334,6 +336,7 @@ class AuthorizedImplTest {
             val credentialAuthorizationSubject = CredentialAuthorizationSubject(
                 credentialRef = CredentialRef.ByCredentialID(credentialInfo.credentialID),
                 documentDigestList = documentDigestList,
+                numSignatures = documents.size,
             )
             coEvery {
                 with(mockClient) {


### PR DESCRIPTION
Upgrade `eudi-lib-jvm-rqes-csc-kt` to `0.7.0-SNAPSHOT` which adds a required `numSignatures` parameter to `CredentialAuthorizationSubject`. Update implementation and tests accordingly.

Also update `kotlinx-io-core` to `0.9.0`, `dokka` to `2.2.0`, `dependency-license-report` to `3.1.1`, and `sonarqube` to `7.2.3.7755`.