### PR TITLE
Add configurable default signing algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ val rqesService = RQESService(
     // default is SHA-256 as shown below
     hashAlgorithm = HashAlgorithmOID.SHA_256,
     // set the default signing algorithm that will be used when signing documents
-    // default is ECDSA with SHA-256 as shown below; it can be overridden per request
-    // in getCredentialAuthorizationUrl and must be supported by the selected credential
-    signingAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
+    // default is SigningAlgorithm.FirstSupportedByCredential, which picks the first
+    // algorithm advertised by the selected credential (credential.key.supportedAlgorithms);
+    // use SigningAlgorithm.Specific to pin a concrete algorithm instead, e.g.
+    // SigningAlgorithm.Specific(SigningAlgorithmOID.ECDSA_SHA256).
+    // The default can be overridden per request in getCredentialAuthorizationUrl and the
+    // resolved algorithm must be supported by the selected credential
+    signingAlgorithm = RQESService.SigningAlgorithm.FirstSupportedByCredential,
     // optionally provide a HttpClientFactory to create a HttpClient for the service
     // this is useful for logging, testing, etc.
     httpClientFactory = {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ val rqesService = RQESService(
     // set the hashing algorithm that will be used
     // default is SHA-256 as shown below
     hashAlgorithm = HashAlgorithmOID.SHA_256,
+    // set the default signing algorithm that will be used when signing documents
+    // default is ECDSA with SHA-256 as shown below; it can be overridden per request
+    // in getCredentialAuthorizationUrl and must be supported by the selected credential
+    signingAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
     // optionally provide a HttpClientFactory to create a HttpClient for the service
     // this is useful for logging, testing, etc.
     httpClientFactory = {
@@ -154,8 +158,10 @@ val credentialAuthorizationUrl = authorizedService.getCredentialAuthorizationUrl
     credential = credential,
     documents = unsignedDocuments,
     // optionally provide the signing algorithm to use when signing the documents
-    // if not provided the first available supported algorithm from the credential 
-    // will be used
+    // if not provided the service's default signing algorithm will be used
+    // the selected algorithm must be supported by the credential; the list of
+    // supported signing algorithms is available on the credential itself via
+    // credential.key.supportedAlgorithms (CredentialInfo)
     signingAlgorithmOID = SigningAlgorithmOID.ECDSA_SHA256
 ).getOrThrow()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml,build/reports/jacoco/testReleaseUnitTestCoverage/testReleaseUnitTestCoverage.xml
 systemProp.sonar.projectName=eudi-lib-android-rqes-core
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0-SNAPSHOT
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESService.kt
+++ b/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESService.kt
@@ -36,15 +36,15 @@ import java.io.File
  * - The credential phase, which handles document signing with authorized credentials
  *
  * @property hashAlgorithm The algorithm OID used for hashing documents during the signing process.
- * @property signingAlgorithm The default signing algorithm OID used when signing documents, unless
- * overridden per request in [Authorized.getCredentialAuthorizationUrl]. The selected algorithm must
+ * @property signingAlgorithm The default [SigningAlgorithm] used when signing documents, unless
+ * overridden per request in [Authorized.getCredentialAuthorizationUrl]. The resolved algorithm must
  * be supported by the credential used for signing.
  */
 interface RQESService {
 
     val hashAlgorithm: HashAlgorithmOID
 
-    val signingAlgorithm: SigningAlgorithmOID
+    val signingAlgorithm: SigningAlgorithm
 
     /**
      * Retrieves the Remote Signature Service Provider (RSSP) metadata.
@@ -159,6 +159,35 @@ interface RQESService {
         suspend fun signDocuments(): Result<SignedDocuments>
     }
 
+    /**
+     * The signing algorithm used as the service default when signing documents.
+     *
+     * The value is resolved to a concrete [SigningAlgorithmOID] at the moment a credential is
+     * selected in [Authorized.getCredentialAuthorizationUrl]. The resolved algorithm must be
+     * supported by that credential, otherwise the operation fails.
+     */
+    sealed interface SigningAlgorithm {
+
+        /**
+         * Uses the first algorithm listed in the selected credential's supported algorithms
+         * (`credential.key.supportedAlgorithms`).
+         *
+         * This guarantees the default is always one the credential supports, at the cost of not
+         * controlling which specific algorithm is chosen.
+         */
+        data object FirstSupportedByCredential : SigningAlgorithm
+
+        /**
+         * Uses the explicitly provided [oid] as the signing algorithm.
+         *
+         * The algorithm must be supported by the selected credential, otherwise resolving it fails
+         * with an [IllegalArgumentException].
+         *
+         * @property oid The signing algorithm OID to use.
+         */
+        data class Specific(val oid: SigningAlgorithmOID) : SigningAlgorithm
+    }
+
     companion object {
         /**
          * Creates an instance of the RQES service.
@@ -170,10 +199,10 @@ interface RQESService {
          * @param config The Cloud Signature Consortium client configuration.
          * @param outputPathDir The directory where signed documents will be stored.
          * @param hashAlgorithm The algorithm OID to use for document hashing, defaults to SHA-256.
-         * @param signingAlgorithm The default signing algorithm OID to use when signing documents,
-         * defaults to ECDSA with SHA-256. It can be overridden per request in
-         * [Authorized.getCredentialAuthorizationUrl] and must be supported by the credential used for
-         * signing.
+         * @param signingAlgorithm The default [SigningAlgorithm] to use when signing documents,
+         * defaults to [SigningAlgorithm.FirstSupportedByCredential]. It can be overridden per request
+         * in [Authorized.getCredentialAuthorizationUrl] and the resolved algorithm must be supported
+         * by the credential used for signing.
          * @param httpClientFactory Optional custom HTTP client factory for network requests.
          * @return A configured [RQESService] implementation.
          * @throws IllegalArgumentException If [outputPathDir] does not point to a valid directory.
@@ -183,7 +212,7 @@ interface RQESService {
             config: CSCClientConfig,
             outputPathDir: String,
             hashAlgorithm: HashAlgorithmOID = HashAlgorithmOID.SHA_256,
-            signingAlgorithm: SigningAlgorithmOID = SigningAlgorithmOID.ECDSA_SHA256,
+            signingAlgorithm: SigningAlgorithm = SigningAlgorithm.FirstSupportedByCredential,
             httpClientFactory: (() -> HttpClient)? = null,
         ): RQESService {
             require(File(outputPathDir).isDirectory) {

--- a/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESService.kt
+++ b/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESService.kt
@@ -36,10 +36,15 @@ import java.io.File
  * - The credential phase, which handles document signing with authorized credentials
  *
  * @property hashAlgorithm The algorithm OID used for hashing documents during the signing process.
+ * @property signingAlgorithm The default signing algorithm OID used when signing documents, unless
+ * overridden per request in [Authorized.getCredentialAuthorizationUrl]. The selected algorithm must
+ * be supported by the credential used for signing.
  */
 interface RQESService {
 
     val hashAlgorithm: HashAlgorithmOID
+
+    val signingAlgorithm: SigningAlgorithmOID
 
     /**
      * Retrieves the Remote Signature Service Provider (RSSP) metadata.
@@ -107,7 +112,7 @@ interface RQESService {
          *
          * @param credential The credential to be used for signing.
          * @param documents The collection of unsigned documents to be signed.
-         * @param signingAlgorithmOID Optional algorithm OID for signing the documents. If null, the first supported algorithm of the credential should be used.
+         * @param signingAlgorithmOID Optional algorithm OID for signing the documents. If null, the service's default signing algorithm is used. In either case the selected algorithm must be supported by the credential, otherwise an error is returned.
          * @return A [Result] containing an [HttpsUrl] for credential authorization if successful,
          *         or an error if the operation failed.
          */
@@ -165,6 +170,10 @@ interface RQESService {
          * @param config The Cloud Signature Consortium client configuration.
          * @param outputPathDir The directory where signed documents will be stored.
          * @param hashAlgorithm The algorithm OID to use for document hashing, defaults to SHA-256.
+         * @param signingAlgorithm The default signing algorithm OID to use when signing documents,
+         * defaults to ECDSA with SHA-256. It can be overridden per request in
+         * [Authorized.getCredentialAuthorizationUrl] and must be supported by the credential used for
+         * signing.
          * @param httpClientFactory Optional custom HTTP client factory for network requests.
          * @return A configured [RQESService] implementation.
          * @throws IllegalArgumentException If [outputPathDir] does not point to a valid directory.
@@ -174,6 +183,7 @@ interface RQESService {
             config: CSCClientConfig,
             outputPathDir: String,
             hashAlgorithm: HashAlgorithmOID = HashAlgorithmOID.SHA_256,
+            signingAlgorithm: SigningAlgorithmOID = SigningAlgorithmOID.ECDSA_SHA256,
             httpClientFactory: (() -> HttpClient)? = null,
         ): RQESService {
             require(File(outputPathDir).isDirectory) {
@@ -184,6 +194,7 @@ interface RQESService {
                 config,
                 outputPathDir,
                 hashAlgorithm,
+                signingAlgorithm,
                 httpClientFactory
             )
         }

--- a/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
+++ b/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
@@ -54,7 +54,7 @@ import kotlin.uuid.Uuid
  * @param config The RQES service configuration.
  * @param outputPathDir Directory where signed documents will be stored.
  * @param hashAlgorithm The algorithm OID, for hashing the documents.
- * @param signingAlgorithm The signing algorithm OID that will be used as default for signing. If not supported by the selected credential then an error is thrown.
+ * @param signingAlgorithm The default [RQESService.SigningAlgorithm] used for signing. The resolved algorithm must be supported by the selected credential, otherwise an error is thrown.
  * @param clientFactory The HTTP client factory. If this property is null, the default HTTP client factory will be used.
  */
 class RQESServiceImpl(
@@ -62,7 +62,7 @@ class RQESServiceImpl(
     @VisibleForTesting internal val config: CSCClientConfig,
     @VisibleForTesting internal val outputPathDir: String,
     override val hashAlgorithm: HashAlgorithmOID,
-    override val signingAlgorithm: SigningAlgorithmOID,
+    override val signingAlgorithm: RQESService.SigningAlgorithm,
     @VisibleForTesting internal val clientFactory: (() -> HttpClient)? = null
 ) : RQESService {
 
@@ -220,7 +220,7 @@ class RQESServiceImpl(
      * @property serviceAccessAuthorized The authorized service access credentials from OAuth2 flow.
      * @property outputPathDir Directory where signed documents will be stored.
      * @property hashAlgorithm The algorithm used for creating document hashes.
-     * @property defaultSigningAlgorithm The signing algorithm to use if not provided through getCredentialAuthorizationUrl method.
+     * @property defaultSigningAlgorithm The default [RQESService.SigningAlgorithm], resolved to a concrete algorithm OID when a credential is selected, and used when none is provided through the [getCredentialAuthorizationUrl] method.
      */
     class AuthorizedImpl(
         @VisibleForTesting internal val serverState: String,
@@ -228,7 +228,7 @@ class RQESServiceImpl(
         @VisibleForTesting internal val serviceAccessAuthorized: ServiceAccessAuthorized,
         @VisibleForTesting internal val outputPathDir: String,
         val hashAlgorithm: HashAlgorithmOID,
-        val defaultSigningAlgorithm: SigningAlgorithmOID
+        val defaultSigningAlgorithm: RQESService.SigningAlgorithm
     ) : RQESService.Authorized {
 
         @VisibleForTesting
@@ -299,7 +299,10 @@ class RQESServiceImpl(
             signingAlgorithmOID: SigningAlgorithmOID?
         ): Result<HttpsUrl> {
             return runCatching {
-                this.signingAlgorithmOID = signingAlgorithmOID ?: defaultSigningAlgorithm
+                this.signingAlgorithmOID = signingAlgorithmOID ?: when (defaultSigningAlgorithm) {
+                    RQESService.SigningAlgorithm.FirstSupportedByCredential -> credential.key.supportedAlgorithms.first()
+                    is RQESService.SigningAlgorithm.Specific -> defaultSigningAlgorithm.oid
+                }
                 require(this.signingAlgorithmOID in credential.key.supportedAlgorithms) {
                     "Signing algorithm not supported by credential"
                 }

--- a/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
+++ b/rqes-core/src/main/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImpl.kt
@@ -54,6 +54,7 @@ import kotlin.uuid.Uuid
  * @param config The RQES service configuration.
  * @param outputPathDir Directory where signed documents will be stored.
  * @param hashAlgorithm The algorithm OID, for hashing the documents.
+ * @param signingAlgorithm The signing algorithm OID that will be used as default for signing. If not supported by the selected credential then an error is thrown.
  * @param clientFactory The HTTP client factory. If this property is null, the default HTTP client factory will be used.
  */
 class RQESServiceImpl(
@@ -61,6 +62,7 @@ class RQESServiceImpl(
     @VisibleForTesting internal val config: CSCClientConfig,
     @VisibleForTesting internal val outputPathDir: String,
     override val hashAlgorithm: HashAlgorithmOID,
+    override val signingAlgorithm: SigningAlgorithmOID,
     @VisibleForTesting internal val clientFactory: (() -> HttpClient)? = null
 ) : RQESService {
 
@@ -198,6 +200,7 @@ class RQESServiceImpl(
                     serviceAccessAuthorized = authorized,
                     outputPathDir = outputPathDir,
                     hashAlgorithm = this@RQESServiceImpl.hashAlgorithm,
+                    defaultSigningAlgorithm = signingAlgorithm
                 )
             }
         }
@@ -217,6 +220,7 @@ class RQESServiceImpl(
      * @property serviceAccessAuthorized The authorized service access credentials from OAuth2 flow.
      * @property outputPathDir Directory where signed documents will be stored.
      * @property hashAlgorithm The algorithm used for creating document hashes.
+     * @property defaultSigningAlgorithm The signing algorithm to use if not provided through getCredentialAuthorizationUrl method.
      */
     class AuthorizedImpl(
         @VisibleForTesting internal val serverState: String,
@@ -224,6 +228,7 @@ class RQESServiceImpl(
         @VisibleForTesting internal val serviceAccessAuthorized: ServiceAccessAuthorized,
         @VisibleForTesting internal val outputPathDir: String,
         val hashAlgorithm: HashAlgorithmOID,
+        val defaultSigningAlgorithm: SigningAlgorithmOID
     ) : RQESService.Authorized {
 
         @VisibleForTesting
@@ -284,7 +289,7 @@ class RQESServiceImpl(
          *
          * @param credential The credential to be used for signing the documents
          * @param documents The collection of unsigned documents to be signed
-         * @param signingAlgorithmOID Optional algorithm OID for signing the documents. If null, the first supported algorithm of the credential will be used.
+         * @param signingAlgorithmOID Optional algorithm OID for signing the documents. If null, the service's default signing algorithm is used. In either case the selected algorithm must be supported by the credential, otherwise an error is returned.
          * @return A [Result] containing the [HttpsUrl] for credential authorization if successful,
          *         or an error if preparation failed
          */
@@ -294,8 +299,7 @@ class RQESServiceImpl(
             signingAlgorithmOID: SigningAlgorithmOID?
         ): Result<HttpsUrl> {
             return runCatching {
-                this.signingAlgorithmOID =
-                    signingAlgorithmOID ?: credential.key.supportedAlgorithms.first()
+                this.signingAlgorithmOID = signingAlgorithmOID ?: defaultSigningAlgorithm
                 require(this.signingAlgorithmOID in credential.key.supportedAlgorithms) {
                     "Signing algorithm not supported by credential"
                 }

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
@@ -30,6 +30,7 @@ import eu.europa.ec.eudi.rqes.HashAlgorithmOID
 import eu.europa.ec.eudi.rqes.HttpsUrl
 import eu.europa.ec.eudi.rqes.ServiceAccessAuthorized
 import eu.europa.ec.eudi.rqes.SigningAlgorithmOID
+import eu.europa.ec.eudi.rqes.core.RQESService.SigningAlgorithm
 import eu.europa.ec.eudi.rqes.core.RQESServiceImpl.AuthorizedImpl
 import io.mockk.coEvery
 import io.mockk.every
@@ -64,7 +65,7 @@ class AuthorizedImplTest {
             serviceAccessAuthorized = serviceAccessAuthorized,
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
-            defaultSigningAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
+            defaultSigningAlgorithm = SigningAlgorithm.Specific(SigningAlgorithmOID.ECDSA_SHA256),
         )
     }
 
@@ -217,7 +218,7 @@ class AuthorizedImplTest {
     }
 
     @Test
-    fun `getCredentialAuthorizationUrl with null signingAlgorithmOID uses the service default signing algorithm`() =
+    fun `getCredentialAuthorizationUrl with null signingAlgorithmOID uses the service default Specific signing algorithm`() =
         runTest {
 
             assertThrows(UninitializedPropertyAccessException::class.java) {
@@ -293,6 +294,85 @@ class AuthorizedImplTest {
             )
             assertEquals(signingAlgorithmOID, authorizedService.signingAlgorithmOID)
 
+        }
+
+    @Test
+    fun `getCredentialAuthorizationUrl with FirstSupportedByCredential default uses the credential's first supported algorithm`() =
+        runTest {
+            val authorizedServiceWithFirstSupported = AuthorizedImpl(
+                serverState = serverState,
+                client = mockClient,
+                serviceAccessAuthorized = serviceAccessAuthorized,
+                outputPathDir = outputPathDir,
+                hashAlgorithm = HashAlgorithmOID.SHA_256,
+                defaultSigningAlgorithm = SigningAlgorithm.FirstSupportedByCredential,
+            )
+
+            val document = UnsignedDocument(
+                label = "my pdf file",
+                file = File.createTempFile(
+                    AuthorizedImplTest::class.simpleName!!, ".pdf"
+                )
+            )
+            // The first entry must differ from the Specific default (ECDSA_SHA256) to prove the
+            // algorithm is taken from the credential and not from a hard-coded default.
+            val firstSupportedAlgorithm = SigningAlgorithmOID.ECDSA_SHA512
+            val documents = UnsignedDocuments(listOf(document))
+            val documentsList = documents.asDocumentToSignList(outputPathDir)
+            val credentialInfo = mockk<CredentialInfo>(relaxed = true) {
+                every { credentialID } returns CredentialID("credential-id")
+                every { certificate } returns mockk()
+                every { key } returns mockk {
+                    every { supportedAlgorithms } returns listOf(
+                        firstSupportedAlgorithm,
+                        SigningAlgorithmOID.ECDSA_SHA256,
+                    )
+                }
+            }
+            val documentDigestList = mockk<DocumentDigestList>()
+
+            coEvery {
+                mockClient.calculateDocumentHashes(
+                    documents = documentsList,
+                    credentialCertificate = credentialInfo.certificate,
+                    hashAlgorithmOID = authorizedServiceWithFirstSupported.hashAlgorithm,
+                )
+            } returns documentDigestList
+
+            val mockAuthorizationCodeURL = HttpsUrl("https://example.com/auth").getOrThrow()
+            val mockAuthorizationRequestPrepared = mockk<AuthorizationRequestPrepared> {
+                every { authorizationCodeURL } returns mockAuthorizationCodeURL
+            }
+            val credentialAuthorizationRequestPrepared =
+                mockk<CredentialAuthorizationRequestPrepared> {
+                    every { authorizationRequestPrepared } returns mockAuthorizationRequestPrepared
+                }
+
+            val credentialAuthorizationSubject = CredentialAuthorizationSubject(
+                credentialRef = CredentialRef.ByCredentialID(credentialInfo.credentialID),
+                documentDigestList = documentDigestList,
+                numSignatures = documents.size,
+            )
+            coEvery {
+                with(mockClient) {
+                    prepareCredentialAuthorizationRequest(
+                        credentialAuthorizationSubject = credentialAuthorizationSubject,
+                        walletState = serverState
+                    )
+                }
+            } returns Result.success(credentialAuthorizationRequestPrepared)
+
+            val result =
+                authorizedServiceWithFirstSupported.getCredentialAuthorizationUrl(
+                    credentialInfo,
+                    documents,
+                )
+            assertTrue(result.isSuccess)
+            assertEquals(mockAuthorizationCodeURL, result.getOrThrow())
+            assertEquals(
+                firstSupportedAlgorithm,
+                authorizedServiceWithFirstSupported.signingAlgorithmOID
+            )
         }
 
     @Test

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/AuthorizedImplTest.kt
@@ -64,6 +64,7 @@ class AuthorizedImplTest {
             serviceAccessAuthorized = serviceAccessAuthorized,
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
+            defaultSigningAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
         )
     }
 
@@ -216,7 +217,7 @@ class AuthorizedImplTest {
     }
 
     @Test
-    fun `getCredentialAuthorizationUrl with null signingAlgorithmOID uses the first supported algorithm`() =
+    fun `getCredentialAuthorizationUrl with null signingAlgorithmOID uses the service default signing algorithm`() =
         runTest {
 
             assertThrows(UninitializedPropertyAccessException::class.java) {

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/ExtensionsTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/ExtensionsTest.kt
@@ -56,6 +56,7 @@ class ExtensionsTest {
             serviceAccessAuthorized = serviceAccessAuthorized,
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
+            defaultSigningAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
         )
     }
 
@@ -67,7 +68,7 @@ class ExtensionsTest {
     @Test
     fun `test Authorized signDocuments extension`() = runTest {
         val authorizationCode = AuthorizationCode(code = "let me in")
-        authorizedService.documentsToSign = listOf(mockk{
+        authorizedService.documentsToSign = listOf(mockk {
             every { label } returns "test document"
             every { documentOutputPath } returns outputPathDir + File.separator + "document.pdf"
         })

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/ExtensionsTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/ExtensionsTest.kt
@@ -56,7 +56,7 @@ class ExtensionsTest {
             serviceAccessAuthorized = serviceAccessAuthorized,
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
-            defaultSigningAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
+            defaultSigningAlgorithm = RQESService.SigningAlgorithm.Specific(SigningAlgorithmOID.ECDSA_SHA256),
         )
     }
 

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImplTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImplTest.kt
@@ -25,6 +25,7 @@ import eu.europa.ec.eudi.rqes.HttpsUrl
 import eu.europa.ec.eudi.rqes.OAuth2Client
 import eu.europa.ec.eudi.rqes.ServiceAccessAuthorized
 import eu.europa.ec.eudi.rqes.ServiceAuthorizationRequestPrepared
+import eu.europa.ec.eudi.rqes.SigningAlgorithmOID
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -60,6 +61,7 @@ class RQESServiceImplTest {
             ),
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
+            signingAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
         )
 
         mockkObject(CSCClient.Companion)

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImplTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceImplTest.kt
@@ -61,7 +61,7 @@ class RQESServiceImplTest {
             ),
             outputPathDir = outputPathDir,
             hashAlgorithm = HashAlgorithmOID.SHA_256,
-            signingAlgorithm = SigningAlgorithmOID.ECDSA_SHA256,
+            signingAlgorithm = RQESService.SigningAlgorithm.Specific(SigningAlgorithmOID.ECDSA_SHA256),
         )
 
         mockkObject(CSCClient.Companion)

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceTest.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.eudi.rqes.core
 import eu.europa.ec.eudi.rqes.CSCClientConfig
 import eu.europa.ec.eudi.rqes.HashAlgorithmOID
 import eu.europa.ec.eudi.rqes.OAuth2Client
+import eu.europa.ec.eudi.rqes.SigningAlgorithmOID
 import io.ktor.client.HttpClient
 import io.mockk.mockk
 import java.net.URI
@@ -53,6 +54,7 @@ class RQESServiceTest {
         assertEquals(config, rqesService.config)
         assertEquals("/tmp", rqesService.outputPathDir)
         assertEquals(HashAlgorithmOID.SHA_256, rqesService.hashAlgorithm)
+        assertEquals(SigningAlgorithmOID.ECDSA_SHA256, rqesService.signingAlgorithm)
         assertEquals(mockkHttpClientFactory, rqesService.clientFactory)
     }
 

--- a/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceTest.kt
+++ b/rqes-core/src/test/kotlin/eu/europa/ec/eudi/rqes/core/RQESServiceTest.kt
@@ -54,7 +54,7 @@ class RQESServiceTest {
         assertEquals(config, rqesService.config)
         assertEquals("/tmp", rqesService.outputPathDir)
         assertEquals(HashAlgorithmOID.SHA_256, rqesService.hashAlgorithm)
-        assertEquals(SigningAlgorithmOID.ECDSA_SHA256, rqesService.signingAlgorithm)
+        assertIs<RQESService.SigningAlgorithm.FirstSupportedByCredential>(rqesService.signingAlgorithm)
         assertEquals(mockkHttpClientFactory, rqesService.clientFactory)
     }
 


### PR DESCRIPTION
This pull request introduces support for configuring a default signing algorithm in the `RQESService` and updates the signing flow to use this default unless overridden per request. The documentation, API, and tests are updated to reflect and verify this behavior.

**API and Implementation Changes:**

* Added a new `signingAlgorithm` property to the `RQESService` interface and its implementation, allowing the default signing algorithm to be specified at service creation. This default is used unless explicitly overridden per signing request. 

**Documentation Updates:**

* Improved the `README.md` to document the new `signingAlgorithm` parameter for service instantiation and clarify the algorithm selection logic in signing requests.
* Updated KDoc comments throughout the codebase to explain the new default signing algorithm behavior and requirements.

**Testing:**

* Updated and extended tests to verify that the service default signing algorithm is used when not explicitly provided, including changes to test setup and test case descriptions.

**Versioning:**

* Bumped the library version to `0.6.0-SNAPSHOT` to reflect the new feature.