### PR TITLE
Update dependencies and replace Jacoco with Kover

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ android.nonTransitiveRClass=true
 
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
-systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml,build/reports/jacoco/testReleaseUnitTestCoverage/testReleaseUnitTestCoverage.xml
+systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/kover/reportDebug.xml,build/reports/kover/reportRelease.xml
 systemProp.sonar.projectName=eudi-lib-android-rqes-core
 VERSION_NAME=0.6.0-SNAPSHOT
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
 androidx-test = "1.7.0"
-bouncy-castle = "1.83"
-dependency-license-report = "3.1.1"
-dependencycheck = "12.2.0"
+bouncy-castle = "1.85"
+dependency-license-report = "3.1.4"
+dependencycheck = "13.0.0"
 dokka = "2.2.0"
 espresso-contrib = "3.7.0"
 espresso-core = "3.7.0"
-eudi-rqes-jvm = "0.7.0"
-gradle-plugin = "8.13.2"
-jacoco = "0.8.12"
+eudi-rqes-jvm = "0.8.0"
+gradle-plugin = "9.2.1"
 java = "17"
 junit-android = "1.3.0"
-kotlin = "2.2.21"
-kotlinx-io = "0.9.0"
-kotlin-coroutines-test = "1.10.2"
+kotlin = "2.3.21"
+kover = "0.9.9"
+kotlinx-io = "0.9.1"
+kotlin-coroutines-test = "1.11.0"
 ktor = "3.2.3"
-mavenPublish = "0.36.0"
-mockk = "1.14.9"
-sonarqube = "7.2.3.7755"
+mavenPublish = "0.37.0"
+mockk = "1.14.11"
+sonarqube = "7.4.0.8496"
 
 [libraries]
 android-junit = { module = "androidx.test.ext:junit", version.ref = "junit-android" }
@@ -38,6 +38,7 @@ test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 test-coreKtx = { module = "androidx.test:core-ktx", version.ref = "androidx-test" }
 test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
 test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "gradle-plugin" }
@@ -45,5 +46,6 @@ dependency-license-report = { id = "com.github.jk1.dependency-license-report", v
 dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "dependencycheck" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 #Thu Sep 12 17:12:58 EEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/licenses.md
+++ b/licenses.md
@@ -1,18 +1,18 @@
 
 # EUDI RQES Core library for Android
 ## Dependency License Report
-_2026-03-31 11:45:16 EEST_
+_2026-08-17 11:38:57 EEST_
 ## Apache License, Version 2.0
 
 **1** **Group:** `io.ktor` **Name:** `ktor-client-android` **Version:** `3.2.3` 
 > - **POM Project URL**: [https://github.com/ktorio/ktor](https://github.com/ktorio/ktor)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**2** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `2.3.0` 
+**2** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `2.3.21` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**3** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-io-core` **Version:** `0.9.0` 
+**3** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-io-core` **Version:** `0.9.1` 
 > - **POM Project URL**: [https://github.com/Kotlin/kotlinx-io](https://github.com/Kotlin/kotlinx-io)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/rqes-core/build.gradle.kts
+++ b/rqes-core/build.gradle.kts
@@ -21,21 +21,16 @@ import com.github.jk1.license.render.InventoryMarkdownReportRenderer
 import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SourcesJar
-import java.util.Locale
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.dokka)
     alias(libs.plugins.dependency.license.report)
     alias(libs.plugins.dependencycheck)
     alias(libs.plugins.sonarqube)
     alias(libs.plugins.maven.publish)
-    jacoco
-}
-
-jacoco {
-    toolVersion = libs.versions.jacoco.get()
+    alias(libs.plugins.kover)
 }
 
 val NAMESPACE: String by project
@@ -61,10 +56,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            enableUnitTestCoverage = true
-            enableAndroidTestCoverage = false
-        }
         release {
             isMinifyEnabled = false
             proguardFiles(
@@ -77,16 +68,18 @@ android {
         sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
         targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     }
-    kotlinOptions {
-        jvmTarget = libs.versions.java.get()
-    }
 
     testOptions {
         unitTests.isReturnDefaultValues = true
     }
 
-    sourceSets.getByName("test").apply {
-        res.setSrcDirs(files("resources"))
+    sourceSets {
+        getByName("test") {
+            res.directories.apply {
+                clear()
+                add("resources")
+            }
+        }
     }
 
     packaging {
@@ -101,11 +94,11 @@ android {
             withSourcesJar()
         }
     }
+}
 
-    androidComponents {
-        onVariants {
-            createJacocoTasks(it.name)
-        }
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.get()))
     }
 }
 
@@ -118,6 +111,7 @@ dependencies {
     runtimeOnly(libs.ktor.client.android)
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.bouncy.castle.pkix)
     testImplementation(libs.bouncy.castle.prov)
     testImplementation(libs.mockk)
@@ -192,111 +186,45 @@ mavenPublishing {
     }
 }
 
-// Jacoco Tasks
+// Code coverage
 
-val coverageExclusions = listOf(
-    "**/databinding/*Binding.*",
-    "**/R.class",
-    "**/R$*.class",
-    "**/BuildConfig.*",
-    "**/Manifest*.*",
-    "**/*Test*.*",
-    "android/**/*.*",
-    // butterKnife
-    "**/*\$ViewInjector*.*",
-    "**/*\$ViewBinder*.*",
-    "**/Lambda\$*.class",
-    "**/Lambda.class",
-    "**/*Lambda.class",
-    "**/*Lambda*.class",
-    "**/*_MembersInjector.class",
-    "**/Dagger*Component*.*",
-    "**/*Module_*Factory.class",
-    "**/di/module/*",
-    "**/*_Factory*.*",
-    "**/*Module*.*",
-    "**/*Dagger*.*",
-    "**/*Hilt*.*",
-    // kotlin
-    "**/*MapperImpl*.*",
-    "**/*\$ViewInjector*.*",
-    "**/*\$ViewBinder*.*",
-    "**/BuildConfig.*",
-    "**/*Component*.*",
-    "**/*BR*.*",
-    "**/Manifest*.*",
-    "**/*\$Lambda\$*.*",
-    "**/*Companion*.*",
-    "**/*Module*.*",
-    "**/*Dagger*.*",
-    "**/*Hilt*.*",
-    "**/*MembersInjector*.*",
-    "**/*_MembersInjector.class",
-    "**/*_Factory*.*",
-    "**/*_Provide*Factory*.*",
-    "**/*Extensions*.*"
-)
-
-fun String.capitalize() =
-    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-
-fun createJacocoTasks(variantName: String) {
-    val testTaskName = "test${variantName.capitalize()}UnitTest"
-    val taskName = "${testTaskName}Coverage"
-    val javaClasses = layout.buildDirectory.dir("intermediates/javac/${variantName}")
-        .get().asFileTree.matching {
-            exclude(coverageExclusions)
-        }
-    val kotlinClasses = layout.buildDirectory.dir("tmp/kotlin-classes/${variantName}")
-        .get().asFileTree.matching {
-            exclude(coverageExclusions)
-        }
-    val sourceDirs = files(
-        "$projectDir/src/main/java",
-        "$projectDir/src/main/kotlin",
-        "$projectDir/src/${variantName}/java",
-        "$projectDir/src/${variantName}/kotlin"
-    )
-    val executionDataVariant =
-        layout.buildDirectory.file("/outputs/unit_test_code_coverage/${variantName}UnitTest/${testTaskName}.exec")
-            .get().asFile
-
-    val reportTask = tasks.register<JacocoReport>(taskName) {
-        group = "reporting"
-        description = "Generate Jacoco coverage reports for the $variantName build."
-        dependsOn(testTaskName)
-        reports {
-            xml.required = true
-            html.required = true
-        }
-        sourceDirectories.setFrom(sourceDirs)
-        classDirectories.setFrom(javaClasses, kotlinClasses)
-        executionData.setFrom(executionDataVariant)
-
-        doLast {
-            layout.buildDirectory.file("reports/jacoco/${taskName}/html/index.html")
-                .get()
-                .asFile
-                .readText()
-                .let { Regex("Total[^%]*>(\\d?\\d?\\d?%)").find(it) }
-                ?.let { println("Test coverage: ${it.groupValues[1]}") }
-        }
-    }
-    tasks.register<JacocoCoverageVerification>("${testTaskName}CoverageVerification") {
-        group = "reporting"
-        description = "Verifies Jacoco coverage for the $variantName build."
-        dependsOn(reportTask.name)
-
-        violationRules {
-            rule {
-                limit {
-                    minimum = 80.toBigDecimal()
-                }
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "*.BuildConfig",
+                    "*.Manifest",
+                    "*.Manifest\$*",
+                    "*.R",
+                    "*.R\$*",
+                    "*ExtensionsKt"
+                )
             }
         }
 
-        classDirectories.setFrom(kotlinClasses, javaClasses)
-        sourceDirectories.setFrom(sourceDirs)
-        executionData.setFrom("${layout.buildDirectory.get()}$executionDataVariant")
+        verify {
+            rule {
+                minBound(80)
+            }
+        }
+    }
+}
+
+// Aliases for the previous Jacoco task names. The shared SAST/Sonar workflow
+// (.github/workflows/sonar.yml) invokes `testDebugUnitTestCoverage` by name.
+listOf("debug", "release").forEach { variant ->
+    val suffix = variant.replaceFirstChar { it.uppercase() }
+
+    tasks.register("test${suffix}UnitTestCoverage") {
+        group = "reporting"
+        description = "Generates Kover coverage reports for the $variant build."
+        dependsOn("koverXmlReport$suffix", "koverHtmlReport$suffix", "koverLog$suffix")
+    }
+
+    tasks.register("test${suffix}UnitTestCoverageVerification") {
+        group = "verification"
+        description = "Verifies Kover coverage for the $variant build."
+        dependsOn("koverVerify$suffix")
     }
 }

--- a/rqes-core/consumer-rules.pro
+++ b/rqes-core/consumer-rules.pro
@@ -1,0 +1,2 @@
+# ProGuard/R8 rules published to consumers of this library.
+# Add rules here that consumers must apply when minifying their apps.

--- a/rqes-core/proguard-rules.pro
+++ b/rqes-core/proguard-rules.pro
@@ -1,0 +1,14 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile


### PR DESCRIPTION
Bump AGP to 9.2.1, Gradle to 9.4.1, Kotlin to 2.3.21, eudi-rqes-jvm to 0.8.0, and the remaining plugins and test libraries.

Fix the build failures the upgrade exposed:

- AGP 9.0 provides built-in Kotlin support and rejects the `org.jetbrains.kotlin.android` plugin, and it no longer offers `android { kotlinOptions { } }`. Drop the plugin and set `jvmTarget` through the `kotlin { compilerOptions { } }` block instead.
- With built-in Kotlin, `kotlin("test")` no longer resolves to the JUnit 4 variant, so every `kotlin.test` annotation and `org.junit` reference in the test sources failed to resolve. Add `kotlin-test-junit` explicitly.
- AGP 9.2.1 declares `LibraryExtension.sourceSets` as a container of the legacy `com.android.build.gradle.api.AndroidLibrarySourceSet`, which the runtime source set no longer implements, so `sourceSets.getByName("test")` failed with a ClassCastException during configuration. Use the correctly typed `sourceSets { }` block, and populate `res.directories` instead of the deprecated `setSrcDirs`.
- bouncy-castle 1.85.
- Add the `consumer-rules.pro` and `proguard-rules.pro` files that the build script references but that were never committed, which now make `mergeDebugConsumerProguardFiles` fail.

Replace Jacoco with Kover for code coverage, as in eudi-lib-android-wallet-core. The Jacoco tasks hardcoded `build/tmp/kotlin-classes/<variant>` and `build/intermediates/javac/<variant>`, which AGP 9 no longer produces, so the reports had been silently empty and the 80% threshold was passing vacuously. Kover derives its inputs from the variant itself and measures 93.4% line coverage.

Keep the 80% minimum via `minBound(80)`, and keep the former `test<Variant>UnitTestCoverage[Verification]` task names as aliases, because the shared SAST workflow invokes `testDebugUnitTestCoverage` by name. Point Sonar at the Kover report paths. Also drop `enableUnitTestCoverage`, which only fed the removed Jacoco tasks and double-instrumented the test JVM.