### PR TITLE
Chore/bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ file.
 ```kotlin
 dependencies {
     // EUDI Wallet RQES service library
-    implementation("eu.europa.ec.eudi:eudi-lib-android-rqes-core:0.5.0")
+    implementation("eu.europa.ec.eudi:eudi-lib-android-rqes-core:0.6.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 systemProp.sonar.coverage.jacoco.xmlReportPaths=build/reports/kover/reportDebug.xml,build/reports/kover/reportRelease.xml
 systemProp.sonar.projectName=eudi-lib-android-rqes-core
-VERSION_NAME=0.6.0-SNAPSHOT
+VERSION_NAME=0.6.0
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false


### PR DESCRIPTION
This pull request updates the project to use version 0.6.0 of the EUDI Wallet RQES service library and finalizes the project version for release.

Dependency and version updates:

* Updated the library dependency in `README.md` to use `eudi-lib-android-rqes-core` version 0.6.0, ensuring the documentation matches the latest stable release.
* Changed `VERSION_NAME` in `gradle.properties` from `0.6.0-SNAPSHOT` to `0.6.0`, marking the project as a stable release instead of a snapshot.